### PR TITLE
Add state parameter to RFC dashboard template

### DIFF
--- a/rfcbot.php
+++ b/rfcbot.php
@@ -354,7 +354,7 @@ foreach ($all_expired as $rfcid) {
 }
 $all_expired = $new_all_expired;
 
-$rfclisting = "{{navbox\n| name = {{subst:FULLPAGENAME}}\n| title = Requests for comment\n| basestyle = background: #BDD8FF;\n| liststyle = line-height: 220%;\n| oddstyle = background: #EEEEEE;\n| evenstyle = background: #DEDEDE;\n";
+$rfclisting = "{{navbox\n| name = {{subst:FULLPAGENAME}}\n| title = Requests for comment\n| state = {{{state|autocollapse}}}\n| basestyle = background: #BDD8FF;\n| liststyle = line-height: 220%;\n| oddstyle = background: #EEEEEE;\n| evenstyle = background: #DEDEDE;\n";
 $counter = 0;
 
 foreach ($RFC_pagetitles as $RFCcategory => $RFCpage) {


### PR DESCRIPTION
Adds optional `state` parameter to the navbox template at [[Wikipedia:Dashboard/Requests for comment]].  This should allow users transcluding this to select whether they want this autoexpanded, autocollapsed, etc.  `autocollapse` is the default for [[Template:Navbox]], so this should change anything currently transcluding the template.