### PR TITLE
Prevent early archival of newly listed RFCs

### DIFF
--- a/rfcbot.php
+++ b/rfcbot.php
@@ -167,7 +167,7 @@ foreach ($transclusions as $page) {
 	foreach ($matches[0] as $match) {
 		if (strpos($match, "|rfcid=") === false) { // if the rfcid is not found within an RFC template
 			$rfcid = generateRfcId(); # a seven-character random string with capital letters and digits
-			$content = str_replace($match, $match . "|rfcid=" . $rfcid . "}}{{subst:DNAU|6|weeks}}", $content);
+			$content = str_replace($match, $match . "|rfcid=" . $rfcid . "}}{{subst:DNAU|5|weeks}}", $content);
 			$content = str_replace("}}|rfcid", "|rfcid", $content);
 			echo "Editing [[$page]]\n";
 			$page->edit($content,"Adding RFC ID.");

--- a/rfcbot.php
+++ b/rfcbot.php
@@ -167,7 +167,7 @@ foreach ($transclusions as $page) {
 	foreach ($matches[0] as $match) {
 		if (strpos($match, "|rfcid=") === false) { // if the rfcid is not found within an RFC template
 			$rfcid = generateRfcId(); # a seven-character random string with capital letters and digits
-			$content = str_replace($match, $match . "|rfcid=" . $rfcid . "}}", $content);
+			$content = str_replace($match, $match . "|rfcid=" . $rfcid . "}}{{subst:DNAU|6|weeks}}", $content);
 			$content = str_replace("}}|rfcid", "|rfcid", $content);
 			echo "Editing [[$page]]\n";
 			$page->edit($content,"Adding RFC ID.");


### PR DESCRIPTION
When RFC bot adds the RFC ID to the talk page section, it should also include a timestamp 6 weeks in the future. A typical RFC is 1 month ~ 4 weeks, and we add 2 weeks (arbitrarily) to that figure so that users can see the result.